### PR TITLE
running znc-buildmod for every .cpp file in /config/modules

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -77,8 +77,6 @@ RUN \
 	ca-certificates && \
 
 # cleanup
- apk del --purge \
-	build-dependencies && \
  rm -rf \
 	/tmp/*
 

--- a/root/etc/cont-init.d/70-build-modules
+++ b/root/etc/cont-init.d/70-build-modules
@@ -1,0 +1,20 @@
+#!/usr/bin/with-contenv sh
+
+# Build modules from source.
+if [ -d "/config/modules" ]; then
+  # Store current directory.
+  cwd="$(pwd)"
+
+  # Find module sources.
+  modules=$(find "/config/modules" -name "*.cpp")
+
+  # Build modules.
+  for module in $modules; do
+    echo "Building module $module..."
+    cd "$(dirname "$module")"
+    znc-buildmod "$module" || exit 1
+  done
+
+  # Go back to original directory.
+  cd "$cwd"
+fi


### PR DESCRIPTION
allowing the container to include custom modules by adding the .cpp files to /config/modules. This does require that the build-dependencies need to remain in the image.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

