### PR TITLE
Added push and clientbuffer modules.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,6 +44,18 @@ RUN \
  tar xf \
  /tmp/playback.tar.gz -C \
 	/tmp/znc/modules --strip-components=1 && \
+ curl -o \
+ /tmp/znc-push.tar.gz -L \
+	https://github.com/jreese/znc-push/archive/master.tar.gz && \
+ tar xf \
+ /tmp/znc-push.tar.gz -C \
+	/tmp/znc/modules --strip-components=1 && \
+ curl -o \
+ /tmp/znc-clientbuffer.tar.gz -L \
+        https://github.com/CyberShadow/znc-clientbuffer/archive/master.tar.gz && \
+ tar xf \
+ /tmp/znc-clientbuffer.tar.gz -C \
+        /tmp/znc/modules --strip-components=1 && \
  cd /tmp/znc && \
  export CFLAGS="$CFLAGS -D_GNU_SOURCE" && \
  ./configure \


### PR DESCRIPTION
This PR replaces #18 since it adds the 'push' module in addition to the 'clientbuffer' module.

Please take a look at this PR and see if it meets your standards.  The 'push' module would be great, as #18 suggests, but since that wasn't merged at all yet, I included it in this PR too, since I would like that functionality in addition to the 'clientbuffer' module, also included in this PR.

The 'clientbuffer' module allows you to specify separate buffers for different clients, which helps organize and send appropriate buffers to clients connecting and disconnecting at different times. Without this module, by default ZNC will only send the buffer to the first client to connect since last disconnect.  Any additional client connections won't receive any buffered messages if the first client is still connected. This module provides a way to deal with that.

Thanks for all your work. This is a fantastic project.

