### PR TITLE
Change to http by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ In this instance `PUID=1000` and `PGID=1000`, to find yours use `id user` as bel
 &nbsp;
 ## Application Setup
 
-To log in to the application, browse to https://<hostip>:6501.
+To log in to the application, browse to http://<hostip>:6501.
 
 * Default User: admin
 * Default Password: admin

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,7 +44,7 @@ optional_block_1: false
 # application setup block
 app_setup_block_enabled: true
 app_setup_block: |
-  To log in to the application, browse to https://<hostip>:6501.
+  To log in to the application, browse to http://<hostip>:6501.
 
   * Default User: admin
   * Default Password: admin

--- a/root/defaults/znc.conf
+++ b/root/defaults/znc.conf
@@ -13,7 +13,7 @@ Version = 1.7.x
 	Port = 6501
 	IPv4 = true
 	IPv6 = false
-	SSL = true
+	SSL = false
 </Listener>
 LoadModule = webadmin
 


### PR DESCRIPTION
Make http default install to fit in with reverse proxy not using double SSL.  Won't affect existing installs