### PR TITLE
retrieve stable tags only

### DIFF
--- a/.github/workflows/external_trigger.yml
+++ b/.github/workflows/external_trigger.yml
@@ -20,7 +20,7 @@ jobs:
           echo "**** External trigger running off of master branch. To disable this trigger, set a Github secret named \"PAUSE_EXTERNAL_TRIGGER_ZNC_MASTER\". ****"
           echo "External trigger running off of master branch. To disable this trigger, set a Github secret named \`PAUSE_EXTERNAL_TRIGGER_ZNC_MASTER\`" >> $GITHUB_STEP_SUMMARY
           echo "**** Retrieving external version ****"
-          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/znc/znc/tags" | jq -r '. | .[0].name')
+          EXT_RELEASE=$(curl -u "${{ secrets.CR_USER }}:${{ secrets.CR_PAT }}" -sX GET "https://api.github.com/repos/znc/znc/tags" | jq -r '. | first(.[] | select(.name | contains("-rc") | not)) | .name')
           if [ -z "${EXT_RELEASE}" ] || [ "${EXT_RELEASE}" == "null" ]; then
             echo "**** Can't retrieve external version, exiting ****"
             FAILURE_REASON="Can't retrieve external version for znc branch master"

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN \
   echo "**** compile znc ****" && \
   if [ -z ${ZNC_RELEASE+x} ]; then \
     ZNC_RELEASE=$(curl -s https://api.github.com/repos/znc/znc/tags \
-    | jq -r ". | .[0].name"); \
+    | jq -r 'first(.[] | select(.name | contains("-rc") | not)) | .name'); \
   fi && \
   mkdir -p \
     /tmp/znc && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -27,7 +27,7 @@ RUN \
   echo "**** compile znc ****" && \
   if [ -z ${ZNC_RELEASE+x} ]; then \
     ZNC_RELEASE=$(curl -s https://api.github.com/repos/znc/znc/tags \
-    | jq -r ". | .[0].name"); \
+    | jq -r 'first(.[] | select(.name | contains("-rc") | not)) | .name'); \
   fi && \
   mkdir -p \
     /tmp/znc && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     GITLAB_NAMESPACE=credentials('gitlab-namespace-id')
     DOCKERHUB_TOKEN=credentials('docker-hub-ci-pat')
     JSON_URL = 'https://api.github.com/repos/znc/znc/tags'
-    JSON_PATH = '.[0].name'
+    JSON_PATH = 'first(.[] | select(.name | contains("-rc") | not)) | .name'
     BUILD_VERSION_ARG = 'ZNC_RELEASE'
     LS_USER = 'linuxserver'
     LS_REPO = 'docker-znc'

--- a/jenkins-vars.yml
+++ b/jenkins-vars.yml
@@ -8,7 +8,7 @@ release_tag: latest
 ls_branch: master
 repo_vars:
   - JSON_URL = 'https://api.github.com/repos/znc/znc/tags'
-  - JSON_PATH = '.[0].name'
+  - JSON_PATH = 'first(.[] | select(.name | contains("-rc") | not)) | .name'
   - BUILD_VERSION_ARG = 'ZNC_RELEASE'
   - LS_USER = 'linuxserver'
   - LS_REPO = 'docker-znc'


### PR DESCRIPTION
Upstream does not do releases, tags only and they do tag RCs as well. RC artifacts are hosted at a different address, hence the hourly failing builds with the latest rc release.

This PR will attempt to filter out RC releases