### PR TITLE
feat: enable libcurl for znc-push

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN \
     boost-dev\
     build-base \
     c-ares-dev \
+    curl-dev \
     cyrus-sasl-dev \
     gettext-dev \
     git \
@@ -55,6 +56,7 @@ RUN \
   tar xf \
     /tmp/znc-push.tar.gz -C \
     /tmp/znc/modules --strip-components=1 && \
+    sed -i '1i #define USE_CURL' /tmp/znc/modules/push.cpp && \
   curl -o \
     /tmp/znc-clientbuffer.tar.gz -L \
     https://github.com/CyberShadow/znc-clientbuffer/archive/master.tar.gz && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -16,6 +16,7 @@ RUN \
     boost-dev\
     build-base \
     c-ares-dev \
+    curl-dev \
     cyrus-sasl-dev \
     gettext-dev \
     git \
@@ -54,6 +55,7 @@ RUN \
   tar xf \
     /tmp/znc-push.tar.gz -C \
     /tmp/znc/modules --strip-components=1 && \
+    sed -i '1i #define USE_CURL' /tmp/znc/modules/push.cpp && \
   curl -o \
     /tmp/znc-clientbuffer.tar.gz -L \
     https://github.com/CyberShadow/znc-clientbuffer/archive/master.tar.gz && \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -77,6 +77,7 @@ init_diagram: |
   "znc:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "09.03.25:", desc: "Enable libcurl for znc-push."}
   - {date: "10.06.24:", desc: "Migrate default config file to newer format."}
   - {date: "06.06.24:", desc: "Rebase to Alpine 3.20."}
   - {date: "26.03.24:", desc: "Switch back to multi-threaded builds and ignore `-beta` and `-alpha` tags as well as `-rc`."}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-znc/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Before enabling libcurl in znc-push, some notifications were not delivered, especially messages that were sent in burst.
Working example:

```
<*push> Building notification to
api.telegram.org/botXXX/sendMessage...
<*push> Request sending
<*push> Status: 200
<*push> Message: OK
...
```

Broken example:

```
<*push> Building notification to
api.telegram.org/botXXX/sendMessage...
<*push> Request sending
...
<Notification not delivered>
```

Ref: https://github.com/amyreese/znc-push/blob/master/README.md#advanced

> Note: You are strongly encouraged to use libcurl transport. The reason for that is, that the default CSocket transport doesn't verify server's SSL certificate which leaves you vulnerable to MITM attacks. However, use of libcurl will block the main ZNC thread at every push notification; for installations with many users, libcurl is not yet ideal, even with the above security concerns in mind.


I subsequently enabled libcurl in push.cpp compilation.
I could not modify the Makefile because it is overwritten for every module downloaded, but I could override the cpp file before building the module.
After using libcurl, I could receive all the notifications sent by znc-push.

## Benefits of this PR and context:

Make znc-push use libcurl for reliable notifications

## How Has This Been Tested?

Rebuilt the docker-znc image and tested it is working: znc-push is using libcurl (`/msg *push set debug on`) 

## Source / References:

https://github.com/amyreese/znc-push/blob/master/README.md#advanced
